### PR TITLE
Return from filterVariance AFTER looping through the list

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -95,12 +95,13 @@ filterVariance = function(rpkm, variance=0.1)
     {
       vari<-apply(rpkm[[v]],1,var)
       index<-which(vari>variance)
-      rpkm[[v]]<-rpkm[[v]][index,]
-      return(rpkm)
+      rpkm[[v]]<-rpkm[[v]][index,] 
     }
   } else {
     return("Object is not a list")
   }
+  
+  return(rpkm)
 }
 
 #'Create gene metadata object


### PR DESCRIPTION
There was a bug: the return from filterVarinace was guaranteed to happen after filtering only the first item in the list. Should loop over the whole list before returning.